### PR TITLE
Preventing premature destruction of objects

### DIFF
--- a/src/communication/communicator.cpp
+++ b/src/communication/communicator.cpp
@@ -34,7 +34,13 @@ void bind_communicator(pybind11::module_ &m)
     py::class_<communicator, std::shared_ptr<communicator>>(m, "Communicator")
         .def_property_readonly("rank", &communicator::get_rank)
         .def_property_readonly("size", &communicator::get_size)
-        .def("split", &communicator::split, py::arg("color"), py::arg("key"))
+        .def(
+            "split", 
+            &communicator::split, 
+            py::arg("color"), 
+            py::arg("key"),
+            py::keep_alive<0, 1>()
+        )
         .def("barrier", &communicator::barrier);
 
 }

--- a/src/communication/communicator_manager.cpp
+++ b/src/communication/communicator_manager.cpp
@@ -56,11 +56,13 @@ void bind_communicator_manager(pybind11::module_ &m)
         .def(
             "create_world_communicator", 
             &communicator_manager::create_world_communicator, 
-            py::arg("name")
+            py::arg("name"),
+            py::keep_alive<0, 1>()
         )
         .def(
             "create_preferred_world_communicator", 
-            &communicator_manager::create_preferred_world_communicator
+            &communicator_manager::create_preferred_world_communicator,
+            py::keep_alive<0, 1>()
         );
 
     m.def(

--- a/src/compute/device.cpp
+++ b/src/compute/device.cpp
@@ -46,13 +46,40 @@ void bind_device(pybind11::module_ &m)
             py::return_value_policy::reference,
             py::keep_alive<0, 1>()
         )
-        .def("create_device_memory_allocator", &device::create_device_memory_allocator)
-        .def("create_host_memory_allocator", &device::create_host_memory_allocator)
-        .def("create_host_to_device_transfer", &device::create_host_to_device_transfer)
-        .def("create_device_to_host_transfer", &device::create_device_to_host_transfer)
-        .def("create_device_copy", &device::create_device_copy)
-        .def("create_device_event", &device::create_device_event)
-        .def("create_device_to_host_event", &device::create_device_to_host_event);
+        .def(
+            "create_device_memory_allocator", 
+            &device::create_device_memory_allocator,
+            py::keep_alive<0, 1>()
+        )
+        .def(
+            "create_host_memory_allocator", 
+            &device::create_host_memory_allocator,
+            py::keep_alive<0, 1>()
+        )
+        .def("create_host_to_device_transfer", 
+            &device::create_host_to_device_transfer,
+            py::keep_alive<0, 1>()
+        )
+        .def(
+            "create_device_to_host_transfer", 
+            &device::create_device_to_host_transfer,
+            py::keep_alive<0, 1>()
+        )
+        .def(
+            "create_device_copy", 
+            &device::create_device_copy,
+            py::keep_alive<0, 1>()
+        )
+        .def(
+            "create_device_event", 
+            &device::create_device_event,
+            py::keep_alive<0, 1>()
+        )
+        .def(
+            "create_device_to_host_event", 
+            &device::create_device_to_host_event,
+            py::keep_alive<0, 1>()
+        );
 
 }
 

--- a/src/compute/device_manager.cpp
+++ b/src/compute/device_manager.cpp
@@ -91,7 +91,8 @@ void bind_device_manager(pybind11::module_ &m)
                 }
 
                 return result;
-            }
+            },
+            py::keep_alive<0, 1>()
         );
 
     m.def(

--- a/src/compute/device_queue_pool.cpp
+++ b/src/compute/device_queue_pool.cpp
@@ -37,22 +37,23 @@ void bind_device_queue_pool(pybind11::module_ &m)
     py::class_<device_queue_pool>(m, "DeviceQueuePool")
         .def_property_readonly(
             "queues",
-            [](device_queue_pool &self) -> py::list
+            [](py::object &self) -> py::list
             {
                 py::list queues;
-                const auto size = self.get_size();
+
+                auto &pool = self.cast<device_queue_pool&>();
+                const auto size = pool.get_size();
                 for (std::size_t i = 0; i < size; ++i)
                 {
                     auto queue = py::cast(
-                        self.get_queue(i), 
-                        py::return_value_policy::reference
-                        // FIXME keep alive the parent object as long as any of the queues is alive
+                        pool.get_queue(i), 
+                        py::return_value_policy::reference_internal,
+                        self
                     );
                     queues.append(std::move(queue));
                 }
                 return queues;
-            },
-            py::return_value_policy::reference_internal
+            }
         );
 }
 

--- a/src/compute/device_queue_pool.cpp
+++ b/src/compute/device_queue_pool.cpp
@@ -46,6 +46,7 @@ void bind_device_queue_pool(pybind11::module_ &m)
                     auto queue = py::cast(
                         self.get_queue(i), 
                         py::return_value_policy::reference
+                        // FIXME keep alive the parent object as long as any of the queues is alive
                     );
                     queues.append(std::move(queue));
                 }

--- a/src/plugin_manager.cpp
+++ b/src/plugin_manager.cpp
@@ -54,24 +54,24 @@ void bind_plugin_manager(pybind11::module_ &m)
         )
         .def_property_readonly(
             "plugins",
-            [](const plugin_manager &manager) -> py::list
+            [](const py::object &self) -> py::list
             {
                 py::list result;
                 
+                const auto &manager = self.cast<const plugin_manager&>();
                 const auto count = manager.get_plugin_count();
                 for (std::size_t i = 0; i < count; ++i)
                 {
                     auto object = py::cast(
                         manager.get_plugin(i), 
-                        py::return_value_policy::reference
-                        // FIXME keep alive the manager
+                        py::return_value_policy::reference_internal,
+                        self
                     );
                     result.append(std::move(object));
                 }
 
                 return result;
-            },
-            py::return_value_policy::reference_internal
+            }
         );
 
     m.def("get_plugin_directory", &get_plugin_directory);

--- a/src/plugin_manager.cpp
+++ b/src/plugin_manager.cpp
@@ -64,6 +64,7 @@ void bind_plugin_manager(pybind11::module_ &m)
                     auto object = py::cast(
                         manager.get_plugin(i), 
                         py::return_value_policy::reference
+                        // FIXME keep alive the manager
                     );
                     result.append(std::move(object));
                 }


### PR DESCRIPTION
Created objects keep alive the manager so that plugins cannot be unloaded until all objects are destroyed