### PR TITLE
Adding missing dependency to the deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,7 @@ jobs:
 
   create_developer_release:
     name: Create development release
-    needs: [build_sdist]
+    needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Not waiting to build wheels causes a premature release without the wheel binaries