### PR TITLE
Fix xmipp4-core dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@
 [build-system]
 requires = [
     "scikit-build-core==0.10",
-    "xmipp4-core==0.1"
+    "xmipp4-core==0.1.*"
 ]
 build-backend = "scikit_build_core.build"
 


### PR DESCRIPTION
This will allow retrieving any version with major fixed to `0` and minor to `1`, always going for the latest version within that restriction.