### PR TITLE
Skip free-threaded Python builds on windows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -161,4 +161,3 @@ jobs:
           draft: false
           prerelease: true
           files: dist/**
-


### PR DESCRIPTION
`cp314t-win_amd64` build was failing with error message:
```
Building wheel...
  
  + python -m build 'D:\a\xmipp4-binding-python\xmipp4-binding-python' --wheel '--outdir=C:\Users\runneradmin\AppData\Local\Temp\cibw-run-v5hlslkn\cp314t-win_amd64\built_wheel'
  * Creating isolated environment: venv+pip...
  * Installing packages in isolated environment:
    - scikit-build-core==0.10
    - xmipp4-core==0.1.*
  * Getting build dependencies for wheel...
  WARNING: Use build.verbose instead of cmake.verbose for scikit-build-core >= 0.10
  * Building wheel...
  WARNING: Use build.verbose instead of cmake.verbose for scikit-build-core >= 0.10
  *** scikit-build-core 0.10.0 using CMake 3.31.6 (wheel)
  *** Configuring CMake...
  loading initial cache file C:\Users\RUNNER~1\AppData\Local\Temp\tmpr6fq9a5l\build\CMakeInit.txt
  -- Building for: Visual Studio 17 2022
  -- The C compiler identification is MSVC 19.44.35213.0
  -- The CXX compiler identification is MSVC 19.44.35213.0
  -- Detecting C compiler ABI info
  -- Detecting C compiler ABI info - done
  -- Check for working C compiler: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x64/cl.exe - skipped
  -- Detecting C compile features
  -- Detecting C compile features - done
  -- Detecting CXX compiler ABI info
  -- Detecting CXX compiler ABI info - done
  -- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x64/cl.exe - skipped
  -- Detecting CXX compile features
  -- Detecting CXX compile features - done
  -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
  -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
  -- Looking for pthread_create in pthreads
  -- Looking for pthread_create in pthreads - not found
  -- Looking for pthread_create in pthread
  -- Looking for pthread_create in pthread - not found
  -- Found Threads: TRUE
  -- Found Python: C:\Users\runneradmin\AppData\Local\Temp\build-env-e2tytvi0\Scripts\python.exe (found version "3.14.0") found components: Interpreter Development.Module
  CMake Deprecation Warning at C:/Users/runneradmin/AppData/Local/Temp/tmpr6fq9a5l/build/_deps/pybind11-src/CMakeLists.txt:13 (cmake_minimum_required):
    Compatibility with CMake < 3.10 will be removed from a future version of
    CMake.
  
    Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
    to tell CMake that the project requires at least <min> but has been updated
    to work with policies introduced by <max> or earlier.
  
  
  -- pybind11 v2.12.0 
  -- Found PythonInterp: C:/Users/runneradmin/AppData/Local/Temp/build-env-e2tytvi0/Scripts/python.exe (found suitable version "3.14", minimum required is "3.6")
  -- Found PythonLibs: C:/Users/runneradmin/AppData/Local/pypa/cibuildwheel/Cache/nuget-cpython/python-freethreaded.3.14.0-rc1/tools/libs/python314t.lib
  -- Performing Test HAS_MSVC_GL_LTCG
  -- Performing Test HAS_MSVC_GL_LTCG - Success
  -- Configuring done (9.3s)
  -- Generating done (0.1s)
  -- Build files have been written to: C:/Users/runneradmin/AppData/Local/Temp/tmpr6fq9a5l/build
  *** Building project with Visual Studio 17 2022...
  MSBuild version 17.14.18+a338add32 for .NET Framework
  
    1>Checking Build System
    Building Custom Rule D:/a/xmipp4-binding-python/xmipp4-binding-python/src/CMakeLists.txt
    communicator.cpp
    communicator_manager.cpp
    device.cpp
    device_event.cpp
    device_index.cpp
    device_manager.cpp
    device_properties.cpp
    device_queue.cpp
    device_queue_pool.cpp
    device_to_host_event.cpp
    device_type.cpp
    location.cpp
    interface_catalog.cpp
    plugin.cpp
    plugin_manager.cpp
    version.cpp
    main.cpp
    main.cpp
    main.cpp
    main.cpp
  LINK : fatal error LNK1104: cannot open file 'python314.lib' [C:\Users\runneradmin\AppData\Local\Temp\tmpr6fq9a5l\build\src\_core_binding.vcxproj]
  
  *** CMake build failed
  
  ERROR Backend subprocess exited when trying to invoke build_wheel
  Error: cibuildwheel: Command ['C:\\Users\\runneradmin\\AppData\\Local\\Temp\\cibw-run-v5hlslkn\\cp314t-win_amd64\\build\\venv\\Scripts\\python.EXE', '-m', 'build', 'D:\\a\\xmipp4-binding-python\\xmipp4-binding-python', '--wheel', '--outdir=C:\\Users\\runneradmin\\AppData\\Local\\Temp\\cibw-run-v5hlslkn\\cp314t-win_amd64\\built_wheel'] failed with code 1.
```