### PR TITLE
Add Python enrichment layer: active device context + implicit context in functional

### DIFF
--- a/python/xmipp4/__init__.py
+++ b/python/xmipp4/__init__.py
@@ -8,9 +8,12 @@ __core_lib = load_core()
 
 from ._core_binding import (
 	__doc__, __version__,
-	hardware, ndarray, numerical, dispatch, functional,
+	hardware, ndarray, numerical, dispatch,
 	ServiceCatalog,
 	PluginManager, Plugin, get_plugin_directory, get_default_plugin_directory,
 	Version
 )
 from ._catalog import get_default_catalog
+from ._context import get_active_execution_context
+from ._device import device
+from . import functional

--- a/python/xmipp4/_context.py
+++ b/python/xmipp4/_context.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: GPL-3.0-only
+
+from __future__ import annotations
+from typing import Optional
+import threading
+
+from ._core_binding.dispatch import ExecutionContext
+
+__local = threading.local()
+
+def get_active_execution_context() -> Optional[ExecutionContext]:
+	"""
+	Get the execution context currently active on this thread.
+
+	The active execution context is set by entering a
+	`with xmipp4.device.backend(...):` block, and is used as the default
+	`context` argument by `xmipp4.functional` when none is given explicitly.
+	It is thread-local: each thread has its own, defaulting to None.
+
+	Returns:
+		Optional[ExecutionContext]: The active execution context, or None
+		if none is active on this thread.
+	"""
+	return getattr(__local, "execution_context", None)
+
+def _set_active_execution_context(
+	context: Optional[ExecutionContext]
+) -> Optional[ExecutionContext]:
+	"""Set the active execution context, returning the previous one."""
+	previous = get_active_execution_context()
+	__local.execution_context = context
+	return previous

--- a/python/xmipp4/_device.py
+++ b/python/xmipp4/_device.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: GPL-3.0-only
+
+from __future__ import annotations
+from typing import Optional, Union
+
+from ._core_binding import hardware, dispatch
+from ._catalog import get_default_catalog
+from ._context import _set_active_execution_context
+
+class _ActiveDeviceContext:
+	"""Context manager that activates an ExecutionContext for its duration."""
+
+	def __init__(self, spec: Union[str, hardware.DeviceIndex]) -> None:
+		self.__spec = spec
+		self.__previous: Optional[dispatch.ExecutionContext] = None
+
+	def __enter__(self) -> dispatch.ExecutionContext:
+		index = (
+			hardware.DeviceIndex(self.__spec)
+			if isinstance(self.__spec, str)
+			else self.__spec
+		)
+
+		catalog = get_default_catalog()
+		session = hardware.get_device_manager(catalog).create_device_session(index)
+		device_context = hardware.DeviceContext(session)
+		program_manager = dispatch.get_program_manager(catalog)
+		context_dispatcher = dispatch.make_eager_dispatcher(program_manager)
+		context = dispatch.ExecutionContext(device_context, context_dispatcher)
+
+		self.__previous = _set_active_execution_context(context)
+		return context
+
+	def __exit__(self, *exc_info) -> bool:
+		_set_active_execution_context(self.__previous)
+		return False
+
+class Device:
+	"""
+	Enriches xmipp4's hardware devices with ergonomics not provided by the
+	raw binding, such as activating an execution context for a `with` block.
+	"""
+
+	def backend(
+		self, spec: Union[str, hardware.DeviceIndex]
+	) -> _ActiveDeviceContext:
+		"""
+		Activate a device as the current thread's execution context.
+
+		Builds a device session, device context, and dispatcher for the
+		given device, and makes the resulting execution context the active
+		one (see `xmipp4.get_active_execution_context`) for the duration of
+		the `with` block, restoring the previously active one on exit.
+
+		Args:
+			spec: The device to activate, either a "backend:id" /
+				"backend" string (see `xmipp4.hardware.DeviceIndex`) or an
+				already constructed DeviceIndex.
+
+		Returns:
+			A context manager yielding the activated ExecutionContext.
+		"""
+		return _ActiveDeviceContext(spec)
+
+device = Device()

--- a/python/xmipp4/functional/__init__.py
+++ b/python/xmipp4/functional/__init__.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: GPL-3.0-only
+
+from __future__ import annotations
+from typing import Any, Optional
+
+from .._core_binding import functional as _raw
+from .._core_binding.ndarray import Array, ArrayDescriptor
+from .._core_binding.numerical import NumericalType
+from .._core_binding.hardware import MemoryResourceAffinity
+from .._core_binding.dispatch import ExecutionContext
+from .._context import get_active_execution_context
+
+def _resolve_context(context: Optional[ExecutionContext]) -> ExecutionContext:
+	if context is None:
+		context = get_active_execution_context()
+		if context is None:
+			raise RuntimeError(
+				"No execution context was provided and there is no active "
+				"device context. Pass context= explicitly or use "
+				"'with xmipp4.device.backend(...):'."
+			)
+	return context
+
+# -- arithmetic -----------------------------------------------------------
+
+def add(
+	x: Array, y: Array,
+	context: Optional[ExecutionContext] = None,
+	out: Optional[Array] = None
+) -> Array:
+	return _raw.add(x, y, _resolve_context(context), out)
+
+def subtract(
+	x: Array, y: Array,
+	context: Optional[ExecutionContext] = None,
+	out: Optional[Array] = None
+) -> Array:
+	return _raw.subtract(x, y, _resolve_context(context), out)
+
+def negate(
+	x: Array,
+	context: Optional[ExecutionContext] = None,
+	out: Optional[Array] = None
+) -> Array:
+	return _raw.negate(x, _resolve_context(context), out)
+
+def abs(
+	x: Array,
+	context: Optional[ExecutionContext] = None,
+	out: Optional[Array] = None
+) -> Array:
+	return _raw.abs(x, _resolve_context(context), out)
+
+def multiply(
+	x: Array, y: Array,
+	context: Optional[ExecutionContext] = None,
+	out: Optional[Array] = None
+) -> Array:
+	return _raw.multiply(x, y, _resolve_context(context), out)
+
+def divide(
+	x: Array, y: Array,
+	context: Optional[ExecutionContext] = None,
+	out: Optional[Array] = None
+) -> Array:
+	return _raw.divide(x, y, _resolve_context(context), out)
+
+def modulo(
+	x: Array, y: Array,
+	context: Optional[ExecutionContext] = None,
+	out: Optional[Array] = None
+) -> Array:
+	return _raw.modulo(x, y, _resolve_context(context), out)
+
+# -- cast -------------------------------------------------------------------
+
+def cast(
+	input: Array, target_type: NumericalType,
+	context: Optional[ExecutionContext] = None
+) -> Array:
+	return _raw.cast(input, target_type, _resolve_context(context))
+
+def cast_copy(
+	input: Array, target_type: NumericalType,
+	context: Optional[ExecutionContext] = None,
+	out: Optional[Array] = None
+) -> Array:
+	return _raw.cast_copy(input, target_type, _resolve_context(context), out)
+
+# -- transfer -----------------------------------------------------------
+
+def transfer(
+	input: Array, affinity: MemoryResourceAffinity,
+	context: Optional[ExecutionContext] = None
+) -> Array:
+	return _raw.transfer(input, affinity, _resolve_context(context))
+
+def transfer_copy(
+	input: Array, affinity: MemoryResourceAffinity,
+	context: Optional[ExecutionContext] = None,
+	out: Optional[Array] = None
+) -> Array:
+	return _raw.transfer_copy(input, affinity, _resolve_context(context), out)
+
+def to_device(
+	input: Array,
+	context: Optional[ExecutionContext] = None
+) -> Array:
+	return _raw.to_device(input, _resolve_context(context))
+
+def to_device_copy(
+	input: Array,
+	context: Optional[ExecutionContext] = None,
+	out: Optional[Array] = None
+) -> Array:
+	return _raw.to_device_copy(input, _resolve_context(context), out)
+
+def to_host(
+	input: Array,
+	context: Optional[ExecutionContext] = None
+) -> Array:
+	return _raw.to_host(input, _resolve_context(context))
+
+def to_host_copy(
+	input: Array,
+	context: Optional[ExecutionContext] = None,
+	out: Optional[Array] = None
+) -> Array:
+	return _raw.to_host_copy(input, _resolve_context(context), out)
+
+# -- creation -----------------------------------------------------------
+
+def empty(
+	descriptor: ArrayDescriptor, affinity: MemoryResourceAffinity,
+	context: Optional[ExecutionContext] = None,
+	out: Optional[Array] = None
+) -> Array:
+	return _raw.empty(descriptor, affinity, _resolve_context(context), out)
+
+def zeros(
+	descriptor: ArrayDescriptor, affinity: MemoryResourceAffinity,
+	context: Optional[ExecutionContext] = None,
+	out: Optional[Array] = None
+) -> Array:
+	return _raw.zeros(descriptor, affinity, _resolve_context(context), out)
+
+def ones(
+	descriptor: ArrayDescriptor, affinity: MemoryResourceAffinity,
+	context: Optional[ExecutionContext] = None,
+	out: Optional[Array] = None
+) -> Array:
+	return _raw.ones(descriptor, affinity, _resolve_context(context), out)
+
+def full(
+	descriptor: ArrayDescriptor, affinity: MemoryResourceAffinity, fill_value: Any,
+	context: Optional[ExecutionContext] = None,
+	out: Optional[Array] = None
+) -> Array:
+	return _raw.full(descriptor, affinity, fill_value, _resolve_context(context), out)
+
+def copy(
+	source: Array,
+	context: Optional[ExecutionContext] = None,
+	out: Optional[Array] = None
+) -> Array:
+	return _raw.copy(source, _resolve_context(context), out)
+
+def fill(
+	out: Array, fill_value: Any,
+	context: Optional[ExecutionContext] = None
+) -> None:
+	_raw.fill(out, fill_value, _resolve_context(context))

--- a/tests/functional/test_active_context.py
+++ b/tests/functional/test_active_context.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: GPL-3.0-only
+
+import pytest
+
+import xmipp4
+
+def test_raises_without_context_and_without_active_device():
+	descriptor = xmipp4.ndarray.make_contiguous_array_descriptor(
+		[2, 2], xmipp4.numerical.NumericalType.float32
+	)
+	with pytest.raises(RuntimeError):
+		xmipp4.functional.zeros(descriptor, xmipp4.hardware.MemoryResourceAffinity.host)
+
+def test_uses_active_context_when_none_given():
+	descriptor = xmipp4.ndarray.make_contiguous_array_descriptor(
+		[2, 2], xmipp4.numerical.NumericalType.float32
+	)
+	with xmipp4.device.backend('cpu'):
+		result = xmipp4.functional.zeros(
+			descriptor, xmipp4.hardware.MemoryResourceAffinity.host
+		)
+	assert isinstance(result, xmipp4.ndarray.Array)
+
+def test_explicit_context_still_works_outside_a_with_block():
+	catalog = xmipp4.ServiceCatalog()
+	manager = xmipp4.hardware.get_device_manager(catalog)
+	session = manager.create_device_session(xmipp4.hardware.DeviceIndex('cpu', 0))
+	device_context = xmipp4.hardware.DeviceContext(session)
+	program_manager = xmipp4.dispatch.get_program_manager(catalog)
+	dispatcher = xmipp4.dispatch.make_eager_dispatcher(program_manager)
+	context = xmipp4.dispatch.ExecutionContext(device_context, dispatcher)
+
+	descriptor = xmipp4.ndarray.make_contiguous_array_descriptor(
+		[2, 2], xmipp4.numerical.NumericalType.float32
+	)
+	result = xmipp4.functional.zeros(
+		descriptor, xmipp4.hardware.MemoryResourceAffinity.host, context
+	)
+	assert isinstance(result, xmipp4.ndarray.Array)
+
+def test_explicit_context_overrides_active_context():
+	catalog = xmipp4.ServiceCatalog()
+	manager = xmipp4.hardware.get_device_manager(catalog)
+	session = manager.create_device_session(xmipp4.hardware.DeviceIndex('cpu', 0))
+	device_context = xmipp4.hardware.DeviceContext(session)
+	program_manager = xmipp4.dispatch.get_program_manager(catalog)
+	dispatcher = xmipp4.dispatch.make_eager_dispatcher(program_manager)
+	explicit_context = xmipp4.dispatch.ExecutionContext(device_context, dispatcher)
+
+	descriptor = xmipp4.ndarray.make_contiguous_array_descriptor(
+		[2, 2], xmipp4.numerical.NumericalType.float32
+	)
+	with xmipp4.device.backend('cpu'):
+		result = xmipp4.functional.zeros(
+			descriptor, xmipp4.hardware.MemoryResourceAffinity.host, explicit_context
+		)
+	assert isinstance(result, xmipp4.ndarray.Array)

--- a/tests/test_device_backend.py
+++ b/tests/test_device_backend.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: GPL-3.0-only
+
+import xmipp4
+
+def test_no_active_context_by_default():
+	assert xmipp4.get_active_execution_context() is None
+
+def test_backend_activates_context_for_the_duration_of_the_block():
+	assert xmipp4.get_active_execution_context() is None
+	with xmipp4.device.backend('cpu') as ctx:
+		assert xmipp4.get_active_execution_context() is ctx
+	assert xmipp4.get_active_execution_context() is None
+
+def test_backend_accepts_a_device_index():
+	index = xmipp4.hardware.DeviceIndex('cpu', 0)
+	with xmipp4.device.backend(index) as ctx:
+		assert xmipp4.get_active_execution_context() is ctx
+
+def test_nested_backend_restores_the_outer_context():
+	with xmipp4.device.backend('cpu') as outer:
+		with xmipp4.device.backend('cpu') as inner:
+			assert xmipp4.get_active_execution_context() is inner
+			assert inner is not outer
+		assert xmipp4.get_active_execution_context() is outer
+	assert xmipp4.get_active_execution_context() is None
+
+def test_backend_restores_previous_context_on_exception():
+	with xmipp4.device.backend('cpu') as outer:
+		try:
+			with xmipp4.device.backend('cpu'):
+				raise ValueError('boom')
+		except ValueError:
+			pass
+		assert xmipp4.get_active_execution_context() is outer


### PR DESCRIPTION
## Summary
Stage 3 of the binding renovation (stage 1: #107, stage 2: #108). Pure-Python layer on top of the bindings, per the original notes: raw classes stay bound as-is, a Python wrapper adds ergonomics (their own example: `with device.backend("cuda:0"):`).

- `xmipp4._context`: thread-local "active" `ExecutionContext` + a public `get_active_execution_context()` getter (mirrors `get_default_catalog()`'s pattern from stage 1).
- `xmipp4.device.backend(spec)`: context manager building the full `catalog -> session -> device_context -> program_manager -> dispatcher -> execution_context` chain from a `"backend:id"` string (or a `DeviceIndex`), activating it for the block and restoring the previous one on exit/exception.
- `xmipp4.functional` is now a pure-Python package wrapping the compiled `_core_binding.functional` submodule (same split as `torch._C` vs `torch.*`): all 21 functions gain an optional `context`, defaulting to the active one and raising a clear `RuntimeError` if neither is set. Explicit `context=` still works and takes precedence, so stage 2's tests are unaffected. Written as 21 explicit functions rather than generated wrappers, since the project is typed (`"Typing :: Typed"`) and these will back the `.pyi` stubs planned as a follow-up.

## Test plan
- [x] `pip install . --no-build-isolation` into the repo's `.venv` — 164/164 tests pass (155 existing + 9 new covering the context manager and implicit-context resolution)
- [x] CI green