### PR TITLE
Improve CI: full pip matrix, windows+gcc+ninja, fetch xmipp4-core via release

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,10 @@ jobs:
           compiler: {cc: clang, cxx: clang++}
         - os: windows-latest
           compiler: {cc: cl, cxx: cl}
-          
+        - os: windows-latest
+          compiler: {cc: gcc, cxx: g++}
+          generator: "Ninja"
+
     runs-on: ${{ matrix.os }}
     env:
       BUILD_TYPE: Debug
@@ -33,13 +36,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install xmipp4-core
-        working-directory: ${{ github.workspace }}/../
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git clone https://github.com/gigabit-clowns/xmipp4-core.git
-          cd xmipp4-core
-          git checkout tags/development
-          pip install --no-index --find-links=dist xmipp4-core
-      
+          gh release download development -R gigabit-clowns/xmipp4-core -D "${{ github.workspace }}/../xmipp4-core-dist" -p '*.whl' --clobber
+          pip install --no-index --find-links="${{ github.workspace }}/../xmipp4-core-dist" xmipp4-core
+
       - name: Configure and build with CMake
         uses: threeal/cmake-action@725d1314ccf9ea922805d7e3f9d9bcbca892b406 # v2
         with:
@@ -47,6 +49,7 @@ jobs:
           build-dir: "${{ github.workspace }}/build"
           c-compiler: ${{ matrix.compiler.cc }}
           cxx-compiler: ${{ matrix.compiler.cxx }}
+          generator: ${{ matrix.generator }}
           options: |
             CMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
           run-build: true
@@ -62,19 +65,13 @@ jobs:
         - macos-latest
         - windows-latest
         python-version:
+        - '3.9'
+        - '3.10'
+        - '3.11'
+        - '3.12'
+        - '3.13'
         - '3.14'
-        include:
-        - os: macos-latest
-          python-version: '3.9'
-        - os: macos-latest
-          python-version: '3.10'
-        - os: macos-latest
-          python-version: '3.11'
-        - os: macos-latest
-          python-version: '3.12'
-        - os: macos-latest
-          python-version: '3.13'
-  
+
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -93,13 +90,12 @@ jobs:
         run: python -m pip install --upgrade pip packaging
 
       - name: Install xmipp4-core
-        working-directory: ${{ github.workspace }}/../
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git clone https://github.com/gigabit-clowns/xmipp4-core.git
-          cd xmipp4-core
-          git checkout tags/development
-          pip install --no-index --find-links=dist xmipp4-core
-      
+          gh release download development -R gigabit-clowns/xmipp4-core -D "${{ github.workspace }}/../xmipp4-core/dist" -p '*.whl' --clobber
+          pip install --no-index --find-links="${{ github.workspace }}/../xmipp4-core/dist" xmipp4-core
+
       - name: Install with pip
         run: pip install .[test] -v --find-links="${{ github.workspace }}/../xmipp4-core/dist" -Ccmake.define.BUILD_TESTING=ON
       

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,9 +21,6 @@ jobs:
           compiler: {cc: clang, cxx: clang++}
         - os: windows-latest
           compiler: {cc: cl, cxx: cl}
-        - os: windows-latest
-          compiler: {cc: gcc, cxx: g++}
-          generator: "Ninja"
 
     runs-on: ${{ matrix.os }}
     env:
@@ -49,7 +46,6 @@ jobs:
           build-dir: "${{ github.workspace }}/build"
           c-compiler: ${{ matrix.compiler.cc }}
           cxx-compiler: ${{ matrix.compiler.cxx }}
-          generator: ${{ matrix.generator }}
           options: |
             CMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
           run-build: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,10 +37,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download xmipp4-core binaries # TODO: Remove when xmipp4-core is in Pypi
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git clone https://github.com/gigabit-clowns/xmipp4-core.git ./local_deps/xmipp4-core
-          cd ./local_deps/xmipp4-core
-          git checkout tags/development
+          gh release download development -R gigabit-clowns/xmipp4-core -D local_deps/xmipp4-core/dist -p '*.whl' --clobber
 
       - name: Build wheels
         uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
@@ -75,11 +75,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download xmipp4-core binaries # TODO: Remove when xmipp4-core is in Pypi
-        working-directory: ${{ github.workspace }}/../
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git clone https://github.com/gigabit-clowns/xmipp4-core.git
-          cd xmipp4-core
-          git checkout tags/development
+          gh release download development -R gigabit-clowns/xmipp4-core -D "${{ github.workspace }}/../xmipp4-core/dist" -p '*.whl' --clobber
 
       - name: Install build tool # TODO: Remove when xmipp4-core is in Pypi
         run: pip install build


### PR DESCRIPTION
## Summary
Follow-up from a CI review discussion, not part of the binding renovation itself.

- **`build_with_cmake`**: added `windows-latest` + `gcc`/`g++` + `Ninja`, matching the combination `xmipp4-core`'s own workflow already tests (Windows was only covered by MSVC here).
- **`build_with_pip`**: switched from "latest Python everywhere + full 3.9-3.14 sweep only on macOS" to the full `os x python-version` cross product (24 jobs). Runners are free on this public repo, and unlike `xmipp4-core` (ships a Python-ABI-agnostic wheel, doesn't even matrix on Python version) `xmipp4-python` compiles a real per-ABI extension, so every `(os, python-version)` pair is a genuinely different build target worth testing.
- **Fetching `xmipp4-core`**: replaced `git clone .../xmipp4-core.git && git checkout tags/development` with `gh release download development` everywhere it's used (`build-and-test.yml`'s two jobs, plus `deploy.yml`'s `build_wheels`/`build_sdist`, which had the identical pattern). The wheels are already attached as release assets on the `development` release, so this avoids cloning the whole repository history just to reach a `dist/` directory — same result, far less transferred. All downstream references to the resulting `dist/` path are unchanged.

## Test plan
- [x] YAML syntax validated (`yaml.safe_load`)
- [ ] CI green (this PR is itself the test — first real run of the new matrix/download step)