### PR TITLE
Try removing the Windows git-source-build fallback for xmipp4-core

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,8 +47,6 @@ jobs:
         env:
           CIBW_ARCHS: "${{ matrix.architectures }}"
           CIBW_ENVIRONMENT: 'PIP_FIND_LINKS=local_deps/xmipp4-core/dist' # TODO: Remove when xmipp4-core is in Pypi
-          CIBW_BEFORE_BUILD_WINDOWS: | # FIXME this should not be required
-            pip install git+https://github.com/gigabit-clowns/xmipp4-core@main
           CIBW_TEST_SKIP: "*-win_arm64" # Windows on ARM cannot be tested, raises warning
           CIBW_SKIP: "cp3??t-win*" # Skip Python free-threaded builds on Windows
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >


### PR DESCRIPTION
## Summary
`CIBW_BEFORE_BUILD_WINDOWS` forces a full from-source rebuild of `xmipp4-core` (~10 min, via `pip install git+https://.../xmipp4-core@main`) on every Windows wheel build in `deploy.yml`. It's marked with its own `# FIXME this should not be required` and there's no recorded reason for it (not in the commit history, not in a comment).

`CIBW_ENVIRONMENT: PIP_FIND_LINKS=local_deps/xmipp4-core/dist` already points pip at a prebuilt `xmipp4-core` wheel before `cibuildwheel` runs (populated by the "Download xmipp4-core binaries" step — same location/content whether it comes from the old `git clone` or, since #110, `gh release download`), and that's sufficient on Linux and macOS in the same job.

Draft PR specifically to let CI prove empirically whether the Windows-only override is still needed — if `Build wheels for windows-latest` still passes without it, we drop the ~10 min/build overhead; if it doesn't, we learn why it was there and can restore it with an actual explanation this time.

## Test plan
- [ ] `Build wheels for windows-latest (AMD64 ARM64)` passes without the override