### PR TITLE
Fix delvewheel unable to find msvcp140.dll for Windows ARM64 wheels

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,19 @@ jobs:
         run: |
           gh release download development -R gigabit-clowns/xmipp4-core -D local_deps/xmipp4-core/dist -p '*.whl' --clobber
 
+      - name: Locate MSVC ARM64 redistributable (for delvewheel)
+        # delvewheel resolves DLL dependencies via PATH, which never contains
+        # the arm64 CRT when cross-compiling from an x64 host, so
+        # msvcp140.dll etc. are "not found" for the arm64 wheel unless we
+        # point it there explicitly. See
+        # https://github.com/adang1345/delvewheel/issues/44
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $crt = Get-ChildItem -Path "C:\Program Files\Microsoft Visual Studio\*\*\VC\Redist\MSVC\*\arm64\Microsoft.VC*.CRT" -Directory -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName
+          if (-not $crt) { $crt = $env:RUNNER_TEMP }
+          Add-Content -Path $env:GITHUB_ENV -Value "ARM64_CRT_DIR=$crt"
+
       - name: Build wheels
         uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
         env:
@@ -52,7 +65,7 @@ jobs:
           CIBW_TEST_SKIP: "*-win_arm64" # Windows on ARM cannot be tested, raises warning
           CIBW_SKIP: "cp3??t-win*" # Skip Python free-threaded builds on Windows
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
-            auditwheel repair -w {dest_dir} {wheel} 
+            auditwheel repair -w {dest_dir} {wheel}
             --exclude "libxmipp4-core.so*"
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
             delocate-wheel --require-archs {delocate_archs}
@@ -61,6 +74,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >
             delvewheel repair -w {dest_dir} -v {wheel}
             --exclude xmipp4-core.dll
+            --add-path "${{ env.ARM64_CRT_DIR }}"
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
## Summary
Follow-up from #110/#111. The `Build wheels for windows-latest (AMD64 ARM64)` job on `main` has been failing on the ARM64 leg specifically (run: https://github.com/gigabit-clowns/xmipp4-python/actions/runs/31444142687/job/93634688513), after `--exclude xmipp4-core.dll` (#110) fixed the AMD64 leg:

```
FileNotFoundError: Unable to find library: msvcp140.dll
```

`delvewheel` resolves DLL dependencies via `PATH`, which never includes the arm64 CRT redistributable when cross-compiling from the x64 runner. This is a known, previously-reported `delvewheel` limitation: https://github.com/adang1345/delvewheel/issues/44. The fix (per the issue) is to locate the arm64 redist directory and pass it via `--add-path`. Since the exact path is version-specific (changes with the runner's installed MSVC toolset), it's resolved at runtime with a small PowerShell step rather than hardcoded.

## Test plan
- [ ] `Build wheels for windows-latest (AMD64 ARM64)` passes for both architectures (this PR touches `deploy.yml`, which triggers the workflow on PRs that modify it)

Draft since this is untested outside CI — no local ARM64 cross-compilation toolchain available to verify beforehand.